### PR TITLE
fix: default page set to one

### DIFF
--- a/services/api/product-listing-page-apis/get-product-list-api.ts
+++ b/services/api/product-listing-page-apis/get-product-list-api.ts
@@ -8,10 +8,10 @@ const fetchProductListingFromAPI = async (appName: any, query: any, token: any) 
 
   // Determine the page number and limit based on the pagination method
   if (CONSTANTS.SHOW_MORE_ITEMS === 'load-more') {
-    page_no = query?.url_params?.page;
+    page_no = query?.url_params?.page || 1;
     limit = 12 * Number(query.url_params.page);
   } else if (CONSTANTS.SHOW_MORE_ITEMS === 'paginate') {
-    page_no = query?.url_params?.page;
+    page_no = query?.url_params?.page || 1;
     limit = 12;
   }
 


### PR DESCRIPTION
### Update  

1. **Default Page Handling**  
   - Updated logic to set the default page to `1` if the `page` key is not found in the URL query parameters.  

Let me know if any additional adjustments are needed!  
